### PR TITLE
feat(salons): add offers to salon details and prioritize in listing

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -206,9 +206,16 @@ export default function Home() {
                   />
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between mb-2">
-                      <h3 className="text-xl font-semibold text-foreground" data-testid={`text-salon-name-${salon.id}`}>
-                        {salon.name}
-                      </h3>
+                      <div className="flex items-center">
+                        <h3 className="text-xl font-semibold text-foreground" data-testid={`text-salon-name-${salon.id}`}>
+                          {salon.name}
+                        </h3>
+                        {salon.offers && salon.offers.length > 0 && (
+                          <Badge variant="destructive" className="ml-2">
+                            Offer
+                          </Badge>
+                        )}
+                      </div>
                       <div className="flex items-center space-x-1">
                         <Star className="h-4 w-4 text-yellow-400 fill-current" />
                         <span className="text-sm font-medium text-foreground" data-testid={`text-salon-rating-${salon.id}`}>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -4,6 +4,7 @@ export interface SalonWithDetails extends Salon {
   services: Service[];
   queueCount: number;
   estimatedWaitTime: number;
+  offers: Offer[];
 }
 
 export interface SalonDetails extends Salon {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -183,15 +183,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
           const services = await storage.getServicesBySalon(salon.id);
           const queues = await storage.getQueuesBySalon(salon.id);
           const waitingQueues = queues.filter(q => q.status === 'waiting');
+          const offers = await storage.getOffersBySalon(salon.id);
 
           return {
             ...salon,
             services,
             queueCount: waitingQueues.length,
             estimatedWaitTime: waitingQueues.length * 15,
+            offers: offers.filter(o => o.isActive),
           };
         })
       );
+
+      // Sort salons: those with active offers first
+      salonsWithDetails.sort((a, b) => {
+        const aHasOffers = a.offers.length > 0;
+        const bHasOffers = b.offers.length > 0;
+        return (bHasOffers ? 1 : 0) - (aHasOffers ? 1 : 0);
+      });
 
       res.json(salonsWithDetails);
     } catch (error) {


### PR DESCRIPTION
- Add offers field to SalonWithDetails interface
- Fetch and filter active offers for each salon
- Sort salons with active offers first in the listing
- Display offer badge in salon cards when offers are available