### PR TITLE
feat: add loading screen component with 2-second delay

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -12,6 +13,7 @@ import SalonProfile from "./pages/SalonProfile";
 import Queue from "./pages/Queue";
 import Dashboard from "./pages/Dashboard";
 import NotFound from "@/pages/not-found";
+import LoadingScreen from "./components/LoadingScreen";
 
 function Router() {
   return (
@@ -27,19 +29,34 @@ function Router() {
 }
 
 function App() {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // Simulate app loading
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 2000); // 2 seconds
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <AuthProvider>
-          <WebSocketProvider>
-            <Layout>
-              <Toaster />
-              <Router />
-            </Layout>
-          </WebSocketProvider>
-        </AuthProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <>
+      {isLoading ? <LoadingScreen /> : (
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <AuthProvider>
+              <WebSocketProvider>
+                <Layout>
+                  <Toaster />
+                  <Router />
+                </Layout>
+              </WebSocketProvider>
+            </AuthProvider>
+          </TooltipProvider>
+        </QueryClientProvider>
+      )}
+    </>
   );
 }
 

--- a/client/src/components/LoadingScreen.tsx
+++ b/client/src/components/LoadingScreen.tsx
@@ -1,0 +1,16 @@
+export default function LoadingScreen() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-purple-600 via-pink-600 to-blue-600">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-white">
+          Smart<span className="text-yellow-300">Q</span>
+        </h1>
+        <div className="mt-4 flex justify-center items-center space-x-2">
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce [animation-delay:-0.3s]"></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce [animation-delay:-0.15s]"></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce"></div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a loading screen that displays during app initialization with a gradient background and animated dots. The screen is shown for 2 seconds before the main app content loads to improve perceived performance.