### PR TITLE
feat(user): add optional phone field to user schema

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -23,6 +23,7 @@ const userSchema = new mongoose.Schema({
   id: { type: String, required: true, unique: true },
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
+  phone: { type: String, unique: true, sparse: true },
   password: { type: String, required: true },
   role: { type: String, required: true, default: 'customer', enum: ['customer', 'salon_owner'] },
   loyaltyPoints: { type: Number, default: 0 },

--- a/server/mongoStorage.ts
+++ b/server/mongoStorage.ts
@@ -31,21 +31,26 @@ export class MongoStorage implements IStorage {
 
   async createUser(insertUser: InsertUser): Promise<User> {
     const id = randomUUID();
-    // Hash password
     const hashedPassword = await bcrypt.hash(insertUser.password, 10);
-    
-    const user: Omit<User, 'phone'> & { phone?: string } = {
-      ...insertUser,
+
+    const userObject = {
       id,
+      name: insertUser.name,
+      email: insertUser.email,
+      phone: insertUser.phone, // Explicitly set the phone number
       password: hashedPassword,
+      role: insertUser.role || 'customer',
       loyaltyPoints: 0,
       createdAt: new Date(),
     };
-    
-    delete user.phone; // Ensure phone is not saved
 
-    await UserModel.create(user);
-    return user as User;
+    const createdUserDoc = await UserModel.create(userObject);
+
+    // Mongoose's .create() can return a Mongoose document, not a plain object.
+    // We convert it to a plain object to match the return type.
+    const user = createdUserDoc.toObject() as User;
+
+    return user;
   }
 
   async updateUser(id: string, updates: Partial<User>): Promise<User | undefined> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -88,9 +88,7 @@ export const insertUserSchema = createInsertSchema(users).omit({
   loyaltyPoints: true,
   createdAt: true,
 }).extend({
-  phone: z.string()
-    .min(10, "Phone number must be at least 10 digits")
-    .regex(/^\+[1-9]\d{1,14}$/, "Phone number must include country code (e.g., +1234567890)"),
+  phone: z.union([z.string().min(10).max(15), z.literal('')]).optional().nullable(),
   role: z.enum(["customer", "salon_owner"]).default("customer"),
 });
 


### PR DESCRIPTION
Make phone field optional in both schema and database model to support users without phone numbers. Simplify phone validation and ensure proper handling during user creation.